### PR TITLE
removed let scoping for children and fixed several small issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Gridfinity Block
 
 ## What is it?
-An OpenSCAD model to create custom storage bins for the Gridfinity system. This library defines a solid block that can be customized using built-in subtraction functions to carve out specific shapes, holes, or compartments. And there are magnet holes too! The model requires using a Development Snapshot (2021.12 or newer) of OpenSCAD. The stable 2021.01 will not work for this!
+An OpenSCAD model to create custom storage bins for the Gridfinity system. This library defines a solid block that can be customized using built-in subtraction functions to carve out specific shapes, holes, or compartments. And there are magnet holes too!
 
 <p align="center">
 <img src="https://github.com/user-attachments/assets/aae9cd4e-d49b-428c-865d-8bc6d732be17" alt="gridfinity-block visual" height="200">


### PR DESCRIPTION
- removed "let" scoping for children - everything still seems to work as advertised
- replaced "h" named argument to linear_extrude by just the value, because 2021.01 works that way
- removed $fn = 128; from the file because 2021.01 also applies it to the code that uses the library, making everything slow